### PR TITLE
zsh aliases fix

### DIFF
--- a/scripts/bootstrap-arch.sh
+++ b/scripts/bootstrap-arch.sh
@@ -1,5 +1,8 @@
 echo -e "Starting bootstrap process for Arch"
 
+# update package database
+pacman -Sy
+
 pacman -S git
 pacman -S github-cli
 pacman -S helix
@@ -7,7 +10,13 @@ pacman -S less # needed for running "git log"
 pacman -S stow # needed to create symlinks for dotfiles
 pacman -S sudo
 pacman -S zellij # tmux replacment
+pacman -S bash
 pacman -S zsh
 # install oh-my-zsh
 sh -c "$(curl -fsSL https://raw.github.com/ohmyzsh/ohmyzsh/master/tools/install.sh)"
+
+# languages
 pacman -S rust
+pacman -S go
+pacman -S npm
+

--- a/zsh/.config/zsh/aliases.zsh
+++ b/zsh/.config/zsh/aliases.zsh
@@ -8,6 +8,7 @@ alias zshconfig="hx ~/.zshrc"
 alias ohmyzsh="hx ~/.oh-my-zsh"
 alias hxconfig="hx ~/.config/helix/config.toml"
 alias hxlangconfig="hx ~/.config/helix/languages.toml"
+alias hx="helix" # https://github.com/helix-editor/helix/issues/2335
 alias loadzsh="source ~/.zshrc"
 
 alias gs="git status"
@@ -16,6 +17,7 @@ alias gc="git commit"
 alias gcm="git commit -m"
 alias gca="git commit --amend"
 alias gpo="git pull origin"
+alias gl="git log"
 
 alias la="ls -A"
 alias ll="ls -l"

--- a/zsh/.zshrc
+++ b/zsh/.zshrc
@@ -7,13 +7,6 @@ export ZSH="$HOME/.oh-my-zsh"
 # See https://github.com/ohmyzsh/ohmyzsh/wiki/Themes
 ZSH_THEME="robbyrussell"
 
-# Uncomment the following line to use case-sensitive completion.
-# CASE_SENSITIVE="true"
-
-# Uncomment the following line to use hyphen-insensitive completion.
-# Case-sensitive completion must be off. _ and - will be interchangeable.
-# HYPHEN_INSENSITIVE="true"
-
 # Set auto-update behavior
 zstyle ':omz:update' mode reminder
 zstyle ':omz:update' frequency 7
@@ -23,6 +16,9 @@ ZSH_CONFIG_DIR="$HOME/.config/zsh"
 for config in "$ZSH_CONFIG_DIR"/{aliases, exports, functions, plugins}.zsh; do
   [ -r "$config" ] && source "$config"
 done
+
+# Source aliases.zsh to detect aliases
+source $HOME/.config/zsh/aliases.zsh
 
 # Enable command auto-correction.
 ENABLE_CORRECTION="true"


### PR DESCRIPTION
- Fix zsh aliases by sourcing it in the .zshrc file
- Added helix alias because arch had to use the full "helix" name since another package was already using "hx"
- Added go and npm to bootstrap-arch.sh
