### PR TITLE
Update rust helix config

### DIFF
--- a/helix/languages.toml
+++ b/helix/languages.toml
@@ -5,8 +5,11 @@ auto-format = true
 indent = { tab-width = 4, unit = " " }
 language-servers = ["rust-analyzer"]
 
-[language-server.rust-analyzer.config]
+[language-server.rust-analyzer.config.check]
 checkOnSave = { command = "clippy" }
+
+[language-server.rust-analyzer.config.cargo]
+features = "all"
 
 # Golang configuration
 [[language]]

--- a/scripts/bootstrap-arch.sh
+++ b/scripts/bootstrap-arch.sh
@@ -16,7 +16,8 @@ pacman -S zsh
 sh -c "$(curl -fsSL https://raw.github.com/ohmyzsh/ohmyzsh/master/tools/install.sh)"
 
 # languages
-pacman -S rust
+# pacman -S rust
+pacman -S rustup # using the official rust toolchain rather than arch's pre-compile rust package
 pacman -S go
 pacman -S npm
 

--- a/zsh/.config/zsh/aliases.zsh
+++ b/zsh/.config/zsh/aliases.zsh
@@ -17,6 +17,7 @@ alias gc="git commit"
 alias gcm="git commit -m"
 alias gca="git commit --amend"
 alias gpo="git pull origin"
+unalias gl # oh-my-zsh aliases this to git pull
 alias gl="git log"
 
 alias la="ls -A"


### PR DESCRIPTION
- Replace rust with rustup. Rustup is from the official rust org and rust is the Arch compiled version of rust
- Attempted to fix gl command but not working. Need to remove the "unalias gl" 