### PR TITLE
Remove gl unalias

### DIFF
--- a/zsh/.config/zsh/aliases.zsh
+++ b/zsh/.config/zsh/aliases.zsh
@@ -17,7 +17,6 @@ alias gc="git commit"
 alias gcm="git commit -m"
 alias gca="git commit --amend"
 alias gpo="git pull origin"
-unalias gl # oh-my-zsh aliases this to git pull
 alias gl="git log"
 
 alias la="ls -A"


### PR DESCRIPTION
Unalias gl didn't work to let me use gl for git log. Removing the unalias command for now