### PR TITLE
Update default editor to helix instead of hx for arch

### DIFF
--- a/zsh/.zshrc
+++ b/zsh/.zshrc
@@ -45,9 +45,9 @@ export LANG=en_US.UTF-8
 
 # Preferred editor for local and remote sessions
 if [[ -n $SSH_CONNECTION ]]; then
-  export EDITOR='hx'
+  export EDITOR='helix'
 else
-  export EDITOR='hx'
+  export EDITOR='helix'
 fi
 
 # Keep 1000 lines of history within the shell and save it to ~/.zsh_history:


### PR DESCRIPTION
Arch uses "helix" instead of "hx" for the helix editor. Updating the default editor but this will probably break on ubuntu or other systems where "hx" is used. Need to find a better way to do this