### PR TITLE
Comment out helix alias

### DIFF
--- a/zsh/.config/zsh/aliases.zsh
+++ b/zsh/.config/zsh/aliases.zsh
@@ -8,7 +8,7 @@ alias zshconfig="hx ~/.zshrc"
 alias ohmyzsh="hx ~/.oh-my-zsh"
 alias hxconfig="hx ~/.config/helix/config.toml"
 alias hxlangconfig="hx ~/.config/helix/languages.toml"
-alias hx="helix" # https://github.com/helix-editor/helix/issues/2335
+# alias hx="helix" # https://github.com/helix-editor/helix/issues/2335
 alias loadzsh="source ~/.zshrc"
 
 alias gs="git status"


### PR DESCRIPTION
Alias isn't necessary in fedora, can't find "hx" when trying to start up helix