### PR TITLE
Add additional packages to bootstrap fedora

### DIFF
--- a/scripts/bootstrap-fedora.sh
+++ b/scripts/bootstrap-fedora.sh
@@ -8,8 +8,16 @@ sudo dnf install fastfetch
 sudo dnf install zsh
 sudo dnf install btop
 sudo dnf install lazygit
-sudo dnf install lazydocker
+# sudo dnf install lazydocker
 sudo dnf install tmux
+
+sudo dnf copr enable atim/starship
+sudo dnf install starship
+sudo dnf install fzf
+sudo dnf install zoxide
+sudo dnf install ripgrep
+sudo dnf install eza # should work but can't find https://eza.rocks/
+sudo dnf install fd
 
 sudo dnf install rustup
 sudo dnf install go


### PR DESCRIPTION
Add additional packages to fedora bootstrap. Mostly based off Omarchy https://learn.omacom.io

Eza isn't found when doing dnf install eza